### PR TITLE
fix: パッケージインストール版で nextjs の dev が起動してしまう件を修正

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,9 @@ packages = [
 ]
 exclude = [
     "aw_daily_reporter/web/frontend/**/*",
-    "!aw_daily_reporter/web/frontend/out"
+    "!aw_daily_reporter/web/frontend/out",
+    "node_modules",
+    "node_modules/**/*"
 ]
 include = [
     { path = "aw_daily_reporter/web/frontend/out/**/*", format = ["sdist", "wheel"] }


### PR DESCRIPTION
Closes #18

## 問題

パッケージビルド時に `node_modules/` 全体（約13,000ファイル、49MB）が含まれており、パッケージが著しく肥大化していた。

## 原因

pyproject.toml の `exclude` 設定で `node_modules` を明示的に除外していなかったため、プロジェクトルートの `node_modules/` がパッケージに含まれていた。

## 修正内容

- pyproject.toml の `exclude` に `node_modules` と `node_modules/**/*` を追加

## 効果

| 項目 | 修正前 | 修正後 |
|------|--------|--------|
| パッケージサイズ | 49MB | 1.3MB |
| ファイル数 | 13,317 | 136 |

## 検証

- ✅ `node_modules/` が完全に除外されている
- ✅ `aw_daily_reporter/web/frontend/out/` のみが含まれている
- ✅ 開発ファイル（package.json、src、.next など）は含まれていない