### PR TITLE
fix: レンダラーの tz_convert() エラーを修正

### DIFF
--- a/aw_daily_reporter/timeline/models.py
+++ b/aw_daily_reporter/timeline/models.py
@@ -8,7 +8,7 @@ TypedDictベースのデータ構造を定義します。
 from datetime import datetime
 from typing import Any, Dict, List, Optional, Union
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, field_validator
 
 
 class CategoryRule(BaseModel):
@@ -39,6 +39,22 @@ class TimelineItem(BaseModel):
         extra="allow"
     )  # Allow plugins to add extra fields freely if needed, though metadata is preferred.
 
+    @field_validator("timestamp", mode="before")
+    @classmethod
+    def convert_pandas_timestamp(cls, v: Any) -> datetime:
+        """
+        pandas Timestamp を Python datetime に変換する
+
+        pandas Timestamp の astimezone() は引数が必要だが、
+        Python datetime の astimezone() は引数なしで呼べる。
+        この不整合を解決するため、pandas Timestamp を検出して
+        Python datetime に変換する。
+        """
+        if hasattr(v, "to_pydatetime"):
+            # pandas Timestamp の場合は Python datetime に変換
+            return v.to_pydatetime()
+        return v
+
 
 class WorkStats(BaseModel):
     start: datetime
@@ -46,3 +62,19 @@ class WorkStats(BaseModel):
     working_seconds: float
     break_seconds: float
     afk_seconds: Optional[float] = 0.0
+
+    @field_validator("start", "end", mode="before")
+    @classmethod
+    def convert_pandas_timestamp(cls, v: Any) -> datetime:
+        """
+        pandas Timestamp を Python datetime に変換する
+
+        pandas Timestamp の astimezone() は引数が必要だが、
+        Python datetime の astimezone() は引数なしで呼べる。
+        この不整合を解決するため、pandas Timestamp を検出して
+        Python datetime に変換する。
+        """
+        if hasattr(v, "to_pydatetime"):
+            # pandas Timestamp の場合は Python datetime に変換
+            return v.to_pydatetime()
+        return v

--- a/tests/unit/test_renderer_integration.py
+++ b/tests/unit/test_renderer_integration.py
@@ -1,0 +1,158 @@
+"""
+レンダラー統合テスト
+
+TimelineItem のシリアライゼーションとレンダラーの動作をテストします。
+"""
+
+from datetime import datetime, timezone
+
+import pandas as pd
+
+from aw_daily_reporter.plugins.manager import PluginManager
+from aw_daily_reporter.plugins.renderer_json import JSONRendererPlugin
+from aw_daily_reporter.timeline.models import TimelineItem
+
+
+class TestRendererIntegration:
+    """レンダラーの統合テスト"""
+
+    def test_timeline_item_with_timezone_aware_timestamp(self):
+        """
+        タイムゾーン情報を持つ datetime を含む TimelineItem が
+        正しくシリアライズできることを確認
+
+        Arrange: タイムゾーン付き datetime を持つ TimelineItem を作成
+        Act: model_dump() でシリアライズ
+        Assert: エラーが発生しない
+        """
+        # Arrange
+        ts = datetime(2024, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+        item = TimelineItem(
+            timestamp=ts,
+            duration=300.0,
+            app="TestApp",
+            title="Test Title",
+        )
+
+        # Act & Assert
+        result = item.model_dump()
+        assert result["timestamp"] == ts
+
+    def test_pandas_timestamp_to_timeline_item_conversion(self):
+        """
+        pandas Timestamp から TimelineItem への変換が正しく動作することを確認
+
+        このテストは、manager.py の512-513行目の処理をテストします。
+
+        Arrange: タイムゾーン付き pandas Timestamp を含む DataFrame を作成
+        Act: to_pydatetime() で Python datetime に変換してから TimelineItem を作成
+        Assert: エラーが発生せず、正しく変換される
+        """
+        # Arrange
+        df = pd.DataFrame(
+            {
+                "timestamp": [pd.Timestamp("2024-01-01 12:00:00", tz="UTC")],
+                "duration": [300.0],
+                "app": ["TestApp"],
+                "title": ["Test Title"],
+            }
+        )
+
+        # Act: manager.py と同じ処理を実行
+        df_copy = df.copy()
+        df_copy["timestamp"] = df_copy["timestamp"].apply(
+            lambda x: x.to_pydatetime() if hasattr(x, "to_pydatetime") else x
+        )
+
+        # TimelineItem に変換
+        items = [TimelineItem(**rec) for rec in df_copy.to_dict("records")]
+
+        # Assert
+        assert len(items) == 1
+        assert items[0].app == "TestApp"
+        assert isinstance(items[0].timestamp, datetime)
+
+    def test_json_renderer_with_timezone_aware_timeline(self):
+        """
+        タイムゾーン情報を持つ timeline を JSON レンダラーで出力できることを確認
+
+        Arrange: タイムゾーン付き datetime を持つ TimelineItem のリストを作成
+        Act: JSONRendererPlugin.render() を実行
+        Assert: エラーが発生せず、JSON 文字列が返される
+        """
+        # Arrange
+        ts = datetime(2024, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+        timeline = [
+            TimelineItem(
+                timestamp=ts,
+                duration=300.0,
+                app="TestApp",
+                title="Test Title",
+            )
+        ]
+        report_data = {
+            "date": "2024-01-01",
+            "work_stats": {},
+            "category_stats": {},
+            "project_stats": {},
+            "client_stats": {},
+        }
+        config = {}
+
+        renderer = JSONRendererPlugin()
+
+        # Act
+        output = renderer.render(timeline, report_data, config)
+
+        # Assert
+        assert output is not None
+        assert isinstance(output, str)
+        assert "TestApp" in output
+
+    def test_run_renderers_with_pandas_timestamp_timeline(self):
+        """
+        pandas Timestamp から変換された timeline で run_renderers が動作することを確認
+
+        これは実際のエラーが発生するシナリオをテストします。
+
+        Arrange: pandas Timestamp から変換された TimelineItem のリストを作成
+        Act: PluginManager.run_renderers() を実行
+        Assert: エラーメッセージが含まれない
+        """
+        # Arrange: pandas Timestamp から変換
+        df = pd.DataFrame(
+            {
+                "timestamp": [pd.Timestamp("2024-01-01 12:00:00", tz="UTC")],
+                "duration": [300.0],
+                "app": ["TestApp"],
+                "title": ["Test Title"],
+                "context": [[]],
+            }
+        )
+
+        # manager.py と同じ処理
+        df_copy = df.copy()
+        df_copy["timestamp"] = df_copy["timestamp"].apply(
+            lambda x: x.to_pydatetime() if hasattr(x, "to_pydatetime") else x
+        )
+
+        timeline = [TimelineItem(**rec) for rec in df_copy.to_dict("records")]
+
+        report_data = {
+            "date": "2024-01-01",
+            "work_stats": {},
+            "category_stats": {},
+            "project_stats": {},
+            "client_stats": {},
+        }
+        config = {}
+
+        manager = PluginManager()
+        manager.load_builtin_plugins()
+
+        # Act
+        outputs = manager.run_renderers(timeline, report_data, config)
+
+        # Assert
+        for plugin_id, output in outputs.items():
+            assert not output.startswith("Error rendering:"), f"Renderer {plugin_id} failed: {output}"


### PR DESCRIPTION
## 概要

レポート出力時にレンダラーで `tz_convert() takes exactly 2 positional arguments (1 given)` エラーが発生する問題を修正しました。

Fixes #39

## 問題

pandas Timestamp の `astimezone()` メソッドは引数が必要ですが、Python の `datetime.astimezone()` は引数なしで呼べる不整合がありました。`manager.py` で `to_pydatetime()` を使って変換しようとしていましたが、実際には pandas Timestamp がそのまま `TimelineItem` に格納されていました。

レンダラーで `item.timestamp.astimezone()` を呼ぶと、pandas Timestamp の `astimezone()` が呼ばれ、内部で `tz_convert()` が引数なしで呼ばれてエラーになっていました。

## 解決策

`TimelineItem` と `WorkStats` に Pydantic の `field_validator` を追加し、pandas Timestamp が渡された場合に自動的に Python datetime に変換するようにしました。

## 変更内容

### 📝 ファイル変更
- **aw_daily_reporter/timeline/models.py**
  - `TimelineItem.timestamp` に validator を追加
  - `WorkStats.start` と `WorkStats.end` に validator を追加
  
- **tests/unit/test_renderer_integration.py** (新規作成)
  - 再現テストを追加
  - pandas Timestamp から TimelineItem への変換をテスト
  - レンダラーの統合テストを追加

### ✅ テスト結果

```bash
# 新しいテスト
pytest tests/unit/test_renderer_integration.py -v
# → 4 passed

# 全テスト
pytest tests/unit/ -v
# → 187 passed
```

## 影響範囲

- Markdown Renderer ✅
- AI Context Renderer ✅
- JSON Renderer ✅
- 既存のテストへの影響なし ✅

## 検証方法

```bash
# アプリケーションを起動
python -m aw_daily_reporter.web

# レポート出力（レンダラー）セクションを確認
# → Markdown Renderer と AI Context Renderer が正常に動作
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)