### PR TITLE
refactor: config.json のキー構造をプラグインIDベースに再設計

### DIFF
--- a/aw_daily_reporter/core.py
+++ b/aw_daily_reporter/core.py
@@ -72,7 +72,7 @@ def cmd_report(args) -> None:
     from .shared.settings_manager import ConfigStore
 
     config = ConfigStore.get_instance().load()
-    default_renderer = config.plugin_params.default_renderer
+    default_renderer = config.system.default_renderer
 
     selected_output = None
 

--- a/aw_daily_reporter/data/presets/ja.json
+++ b/aw_daily_reporter/data/presets/ja.json
@@ -1,7 +1,31 @@
 {
   "system": {
     "language": "ja",
-    "day_start_source": "aw"
+    "day_start_source": "aw",
+    "default_renderer": null,
+    "category_list": [
+      "コーディング",
+      "ブラウジング",
+      "コミュニケーション",
+      "ミーティング",
+      "エンターテインメント",
+      "動画",
+      "ゲーム",
+      "AFK",
+      "執筆",
+      "デザイン",
+      "学習",
+      "調査",
+      "管理",
+      "その他"
+    ],
+    "category_colors": {},
+    "break_categories": [
+      "AFK",
+      "エンターテインメント",
+      "動画",
+      "ゲーム"
+    ]
   },
   "apps": {
     "editors": [
@@ -24,32 +48,15 @@
       "webex"
     ]
   },
-  "settings": {
-    "project_extraction_patterns": [
-      "^(?P<project>.+?)\\|"
-    ],
-    "break_categories": [
-      "AFK",
-      "エンターテインメント",
-      "動画",
-      "ゲーム"
-    ],
-    "category_list": [
-      "コーディング",
-      "ブラウジング",
-      "コミュニケーション",
-      "ミーティング",
-      "エンターテインメント",
-      "動画",
-      "ゲーム",
-      "AFK",
-      "執筆",
-      "デザイン",
-      "学習",
-      "調査",
-      "管理",
-      "その他"
-    ]
+  "plugins": {
+    "aw_daily_reporter.plugins.processor_project_extractor.ProjectExtractionProcessor": {
+      "project_extraction_patterns": [
+        "^(?P<project>.+?)\\|"
+      ]
+    },
+    "aw_daily_reporter.plugins.processor_afk.AFKProcessor": {
+      "afk_system_apps": []
+    }
   },
   "rules": [
     {

--- a/aw_daily_reporter/plugins/processor_afk.py
+++ b/aw_daily_reporter/plugins/processor_afk.py
@@ -45,7 +45,7 @@ class AFKProcessor(ProcessorPlugin):
 
     @property
     def required_settings(self) -> list[str]:
-        return ["settings"]
+        return ["plugins"]
 
     def process(self, df: DataFrame[TimelineSchema], config: dict[str, Any]) -> DataFrame[TimelineSchema]:
         logger.info(f"[Plugin] Running: {self.name}")
@@ -54,7 +54,8 @@ class AFKProcessor(ProcessorPlugin):
 
         # Get system apps from config or use default
         system_apps = set(self.SYSTEM_APPS)
-        configured_apps = config.get("settings", {}).get("afk_system_apps", [])
+        plugin_config = config.get("plugins", {}).get(self.plugin_id, {})
+        configured_apps = plugin_config.get("afk_system_apps", [])
         if configured_apps:
             system_apps = {a.lower() for a in configured_apps}
 

--- a/aw_daily_reporter/plugins/processor_project_extractor.py
+++ b/aw_daily_reporter/plugins/processor_project_extractor.py
@@ -35,7 +35,7 @@ class ProjectExtractionProcessor(ProcessorPlugin):
 
     @property
     def required_settings(self) -> list[str]:
-        return ["settings"]
+        return ["plugins"]
 
     def process(self, df: DataFrame[TimelineSchema], config: dict[str, Any]) -> DataFrame[TimelineSchema]:
         logger.info(f"[Plugin] Running: {self.name}")
@@ -43,7 +43,9 @@ class ProjectExtractionProcessor(ProcessorPlugin):
         if df.empty:
             return df
 
-        extraction_patterns = config.get("settings", {}).get("project_extraction_patterns", [])
+        # プラグイン固有の設定を取得
+        plugin_config = config.get("plugins", {}).get(self.plugin_id, {})
+        extraction_patterns = plugin_config.get("project_extraction_patterns", [])
         if not extraction_patterns:
             # Fallback default if not in config? Use generic pipe pattern as a safe default
             extraction_patterns = [r"^(?P<project>.+?)\|"]

--- a/aw_daily_reporter/plugins/renderer_ai.py
+++ b/aw_daily_reporter/plugins/renderer_ai.py
@@ -30,7 +30,7 @@ class AIRendererPlugin(RendererPlugin):
 
     @property
     def required_settings(self) -> list[str]:
-        return ["settings"]
+        return ["plugins"]
 
     def render(
         self,
@@ -41,18 +41,11 @@ class AIRendererPlugin(RendererPlugin):
         logger.info(f"[Plugin] Running: {self.name}")
         lines = []
 
-        # 0. System Prompt (from Settings)
-        # config layout is assumed to be { "settings": { "ai_prompt": "..." } } or flattened by manager?
-        # Based on settings_manager.py, config passed here is likely the full unified config.
-        # But wait, Manager calls plugin.render(..., config).
-        # In manager.py: renderer.render(..., config=self.config_manager.load())
-        # So config is the full dict.
-
-        settings = config.get("settings", {})
-        ai_prompt = settings.get("ai_prompt", "")
-        if not ai_prompt:
-            # Fallback: check root (in case of manual config edit)
-            ai_prompt = config.get("ai_prompt", "")
+        # 0. System Prompt (from plugin config)
+        # config layout is the full unified config dict
+        # プラグイン固有の設定を取得
+        plugin_config = config.get("plugins", {}).get(self.plugin_id, {})
+        ai_prompt = plugin_config.get("ai_prompt", "")
         if ai_prompt:
             lines.append(ai_prompt)
             lines.append("")

--- a/aw_daily_reporter/plugins/renderer_markdown.py
+++ b/aw_daily_reporter/plugins/renderer_markdown.py
@@ -30,7 +30,7 @@ class MarkdownRendererPlugin(RendererPlugin):
 
     @property
     def required_settings(self) -> list[str]:
-        return ["settings"]
+        return ["system"]
 
     def render(
         self,
@@ -74,7 +74,7 @@ class MarkdownRendererPlugin(RendererPlugin):
         if working_seconds > 0:
             time_dist_label = _("Time Distribution (Base: Working Hours)")
             p(f"\n⏱️  {time_dist_label}:")
-            break_cats = config.get("settings", {}).get("break_categories", [])
+            break_cats = config.get("system", {}).get("break_categories", [])
 
             # ソート: 未分類を最後に
             def sort_key(item):

--- a/aw_daily_reporter/timeline/processor.py
+++ b/aw_daily_reporter/timeline/processor.py
@@ -49,7 +49,7 @@ class TimelineStatsCalculator:
         end = max(item.timestamp + timedelta(seconds=item.duration) for item in timeline)
         total_span = (end - start).total_seconds()
 
-        break_categories = config.get("settings", {}).get("break_categories", [])
+        break_categories = config.get("system", {}).get("break_categories", [])
 
         # 2. Filter out explicit AFK events to        # "Active Time" (events that are NOT AFK)
         # Note: Some active events might have category="AFK"

--- a/aw_daily_reporter/web/frontend/src/__tests__/components/ConfigInitializer.test.tsx
+++ b/aw_daily_reporter/web/frontend/src/__tests__/components/ConfigInitializer.test.tsx
@@ -23,7 +23,7 @@ describe("ConfigInitializer", () => {
   it("test_ConfigInitializer_ConfigWithColors_CallsSetColors", async () => {
     // Arrange
     const mockConfig = {
-      settings: {
+      system: {
         category_colors: { Category1: "#ffffff" },
       },
     }
@@ -41,7 +41,7 @@ describe("ConfigInitializer", () => {
     // Assert
     await waitFor(() => {
       expect(setCustomCategoryColors).toHaveBeenCalledWith(
-        mockConfig.settings.category_colors,
+        mockConfig.system.category_colors,
       )
     })
   })
@@ -77,9 +77,9 @@ describe("ConfigInitializer", () => {
   it("test_ConfigInitializer_ConfigWithoutColors_DoesNotCallSetColors", async () => {
     // Arrange
     const mockConfig = {
-      settings: {
+      system: {
         // category_colors missing
-        theme: "dark",
+        language: "ja",
       },
     }
 

--- a/aw_daily_reporter/web/frontend/src/__tests__/hooks/useSettingsState.test.tsx
+++ b/aw_daily_reporter/web/frontend/src/__tests__/hooks/useSettingsState.test.tsx
@@ -1,5 +1,6 @@
 import { act, renderHook } from "@testing-library/react"
 import { beforeEach, describe, expect, it, vi } from "vitest"
+import { PLUGIN_IDS } from "@/constants/pluginIds"
 import { useSettingsState } from "@/hooks/useSettingsState"
 
 // Mock dependencies
@@ -35,14 +36,18 @@ import useSWR from "swr"
 
 describe("useSettingsState", () => {
   const mockConfig = {
-    system: { language: "en" },
+    system: {
+      language: "en",
+      category_list: ["Category A"],
+    },
+    plugins: {
+      [PLUGIN_IDS.PROCESSOR_PROJECT_EXTRACTOR]: {
+        project_extraction_patterns: ["^test"],
+      },
+    },
     rules: [{ keyword: "test", category: "Test", project: "TestProj" }],
     project_map: { "Old Project": "New Project" },
     client_map: { "New Project": "Client A" },
-    settings: {
-      project_extraction_patterns: ["^test"],
-      category_list: ["Category A"],
-    },
   }
 
   beforeEach(() => {
@@ -61,10 +66,11 @@ describe("useSettingsState", () => {
     expect(result.current.localProjectMap).toEqual(mockConfig.project_map)
     expect(result.current.localClientMap).toEqual(mockConfig.client_map)
     expect(result.current.localExtractionPatterns).toEqual(
-      mockConfig.settings.project_extraction_patterns,
+      mockConfig.plugins[PLUGIN_IDS.PROCESSOR_PROJECT_EXTRACTOR]
+        .project_extraction_patterns,
     )
     expect(result.current.localCategoryList).toEqual(
-      mockConfig.settings.category_list,
+      mockConfig.system.category_list,
     )
   })
 

--- a/aw_daily_reporter/web/frontend/src/app/_components/RendererOutputViewer.tsx
+++ b/aw_daily_reporter/web/frontend/src/app/_components/RendererOutputViewer.tsx
@@ -21,7 +21,7 @@ export function RendererOutputViewer({
 
   // Define config type for SWR
   interface Config {
-    settings?: {
+    system?: {
       default_renderer?: string
     }
   }
@@ -32,10 +32,10 @@ export function RendererOutputViewer({
   // Load initial active key from settings or default to first available
   useEffect(() => {
     if (
-      config?.settings?.default_renderer &&
-      keys.includes(config.settings.default_renderer)
+      config?.system?.default_renderer &&
+      keys.includes(config.system.default_renderer)
     ) {
-      setActiveKey(config.settings.default_renderer)
+      setActiveKey(config.system.default_renderer)
     }
   }, [config, keys])
 
@@ -51,7 +51,7 @@ export function RendererOutputViewer({
     // Persist selection
     try {
       await api.patch("/api/settings", {
-        settings: {
+        system: {
           default_renderer: key,
         },
       })
@@ -61,8 +61,8 @@ export function RendererOutputViewer({
           "/api/settings",
           {
             ...config,
-            settings: {
-              ...config.settings,
+            system: {
+              ...config.system,
               default_renderer: key,
             },
           },

--- a/aw_daily_reporter/web/frontend/src/app/settings/tabs/CategoriesTab.tsx
+++ b/aw_daily_reporter/web/frontend/src/app/settings/tabs/CategoriesTab.tsx
@@ -33,7 +33,7 @@ export default function CategoriesTab({
 }: CategoriesTabProps) {
   const { t } = useTranslation()
 
-  if (!config?.settings) return null
+  if (!config?.system) return null
 
   return (
     <div className="h-full overflow-y-auto pr-4 space-y-6">
@@ -57,8 +57,8 @@ export default function CategoriesTab({
                   handleSaveConfig(
                     {
                       ...config,
-                      settings: {
-                        ...config.settings,
+                      system: {
+                        ...config.system,
                         category_list: newCategories,
                       },
                     },
@@ -83,8 +83,8 @@ export default function CategoriesTab({
                 await handleSaveConfig(
                   {
                     ...config,
-                    settings: {
-                      ...config.settings,
+                    system: {
+                      ...config.system,
                       category_list: newCategories,
                       category_colors: newColors,
                       break_categories: newBreaks,
@@ -94,8 +94,8 @@ export default function CategoriesTab({
                 )
               }
             }}
-            initialColors={config?.settings?.category_colors}
-            initialBreakCategories={config?.settings?.break_categories}
+            initialColors={config?.system?.category_colors}
+            initialBreakCategories={config?.system?.break_categories}
           />
         </div>
       </Card>

--- a/aw_daily_reporter/web/frontend/src/app/settings/tabs/GeneralTab.tsx
+++ b/aw_daily_reporter/web/frontend/src/app/settings/tabs/GeneralTab.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { Card } from "@/components/Card"
+import { PLUGIN_IDS } from "@/constants/pluginIds"
 import { useTranslation } from "@/contexts/I18nContext"
 import type { FullConfig, Rule } from "../types"
 
@@ -285,13 +286,16 @@ export default function GeneralTab({
           placeholder={t(
             "e.g., 'Focus on coding activities and provide a summary of the most used languages.'",
           )}
-          value={config.settings?.ai_prompt || ""}
+          value={config.plugins?.[PLUGIN_IDS.RENDERER_AI]?.ai_prompt || ""}
           onChange={(e) =>
             handleSaveConfig({
               ...config,
-              settings: {
-                ...config.settings,
-                ai_prompt: e.target.value,
+              plugins: {
+                ...config.plugins,
+                [PLUGIN_IDS.RENDERER_AI]: {
+                  ...config.plugins?.[PLUGIN_IDS.RENDERER_AI],
+                  ai_prompt: e.target.value,
+                },
               },
             })
           }

--- a/aw_daily_reporter/web/frontend/src/app/settings/tabs/ProjectsTab.tsx
+++ b/aw_daily_reporter/web/frontend/src/app/settings/tabs/ProjectsTab.tsx
@@ -2,6 +2,7 @@
 
 import dynamic from "next/dynamic"
 import { Card } from "@/components/Card"
+import { PLUGIN_IDS } from "@/constants/pluginIds"
 import { useTranslation } from "@/contexts/I18nContext"
 import type { FullConfig } from "../types"
 
@@ -74,9 +75,14 @@ export default function ProjectsTab({
                   await handleSaveConfig(
                     {
                       ...config,
-                      settings: {
-                        ...config.settings,
-                        project_extraction_patterns: newPatterns,
+                      plugins: {
+                        ...config.plugins,
+                        [PLUGIN_IDS.PROCESSOR_PROJECT_EXTRACTOR]: {
+                          ...config.plugins?.[
+                            PLUGIN_IDS.PROCESSOR_PROJECT_EXTRACTOR
+                          ],
+                          project_extraction_patterns: newPatterns,
+                        },
                       },
                     },
                     true,

--- a/aw_daily_reporter/web/frontend/src/app/settings/types.ts
+++ b/aw_daily_reporter/web/frontend/src/app/settings/types.ts
@@ -38,11 +38,23 @@ export interface SystemConfig {
   start_of_day?: string
   aw_start_of_day?: string // Injected from backend
   enabled_bucket_ids?: string[] // Data source bucket filter
+  // システム全体の設定
+  default_renderer?: string
+  category_list?: string[]
+  category_colors?: Record<string, string>
+  break_categories?: string[]
   report?: {
     output_dir?: string
   }
 }
 
+// プラグイン設定のコンテナ型（プラグインID: 設定オブジェクト）
+export interface PluginConfig {
+  [pluginId: string]: any
+}
+
+// 後方互換性のため SettingsConfig を残すが、使用は非推奨
+/** @deprecated Use system.* or plugins[pluginId].* instead */
 export interface SettingsConfig {
   afk_system_apps?: string[]
   break_categories?: string[]
@@ -55,7 +67,8 @@ export interface SettingsConfig {
 
 export interface FullConfig {
   system: SystemConfig
-  settings: SettingsConfig
+  plugins: PluginConfig
+  settings?: SettingsConfig // 後方互換性のため残す
   rules: Rule[]
   categories: Record<string, string>
   project_map: Record<string, string>

--- a/aw_daily_reporter/web/frontend/src/components/ConfigInitializer.tsx
+++ b/aw_daily_reporter/web/frontend/src/components/ConfigInitializer.tsx
@@ -9,8 +9,8 @@ export function ConfigInitializer() {
   const { data: config } = useSWR("/api/settings", fetcher)
 
   useEffect(() => {
-    if (config?.settings?.category_colors) {
-      setCustomCategoryColors(config.settings.category_colors)
+    if (config?.system?.category_colors) {
+      setCustomCategoryColors(config.system.category_colors)
     }
   }, [config])
 

--- a/aw_daily_reporter/web/frontend/src/constants/pluginIds.ts
+++ b/aw_daily_reporter/web/frontend/src/constants/pluginIds.ts
@@ -1,0 +1,9 @@
+// プラグインIDの定数定義
+export const PLUGIN_IDS = {
+  PROCESSOR_PROJECT_EXTRACTOR:
+    "aw_daily_reporter.plugins.processor_project_extractor.ProjectExtractionProcessor",
+  PROCESSOR_AFK: "aw_daily_reporter.plugins.processor_afk.AFKProcessor",
+  RENDERER_MARKDOWN:
+    "aw_daily_reporter.plugins.renderer_markdown.MarkdownRendererPlugin",
+  RENDERER_AI: "aw_daily_reporter.plugins.renderer_ai.AIRendererPlugin",
+} as const

--- a/aw_daily_reporter/web/frontend/src/hooks/useSettingsState.ts
+++ b/aw_daily_reporter/web/frontend/src/hooks/useSettingsState.ts
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useRef, useState } from "react"
 import useSWR, { mutate } from "swr"
 import type { FullConfig, Rule, Tab } from "@/app/settings/types"
+import { PLUGIN_IDS } from "@/constants/pluginIds"
 import { useTranslation } from "@/contexts/I18nContext"
 import { useToast } from "@/contexts/ToastContext"
 import { fetcher } from "@/lib/api"
@@ -61,8 +62,10 @@ export function useSettingsState() {
         rules: config.rules || [],
         projectMap: config.project_map || {},
         clientMap: config.client_map || {},
-        extractionPatterns: config.settings?.project_extraction_patterns || [],
-        categoryList: config.settings?.category_list || [],
+        extractionPatterns:
+          config.plugins?.[PLUGIN_IDS.PROCESSOR_PROJECT_EXTRACTOR]
+            ?.project_extraction_patterns || [],
+        categoryList: config.system?.category_list || [],
       })
     }
   }, [config])

--- a/tests/unit/test_core.py
+++ b/tests/unit/test_core.py
@@ -11,7 +11,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from aw_daily_reporter.shared.settings_manager import AppConfig, PluginParams, SystemConfig
+from aw_daily_reporter.shared.settings_manager import AppConfig, PluginsConfig, SystemConfig
 
 
 class TestCmdReport(unittest.TestCase):
@@ -27,7 +27,7 @@ class TestCmdReport(unittest.TestCase):
         mock_date_range.return_value = (MagicMock(), MagicMock())
         mock_settings.get_instance.return_value.load.return_value = AppConfig(
             system=SystemConfig(start_of_day="00:00", day_start_source="manual"),
-            plugin_params=PluginParams(),
+            plugins=PluginsConfig(),
         )
         mock_generator.return_value.run.return_value = (
             {},
@@ -53,7 +53,7 @@ class TestCmdReport(unittest.TestCase):
         mock_date_range.return_value = (MagicMock(), MagicMock())
         mock_settings.get_instance.return_value.load.return_value = AppConfig(
             system=SystemConfig(start_of_day="00:00", day_start_source="manual"),
-            plugin_params=PluginParams(),
+            plugins=PluginsConfig(),
         )
         mock_generator.return_value.run.return_value = (
             {},
@@ -81,7 +81,7 @@ class TestCmdReport(unittest.TestCase):
         mock_date_range.return_value = (MagicMock(), MagicMock())
         mock_settings.get_instance.return_value.load.return_value = AppConfig(
             system=SystemConfig(start_of_day="00:00", day_start_source="manual"),
-            plugin_params=PluginParams(),
+            plugins=PluginsConfig(),
         )
         mock_generator.return_value.run.return_value = (
             {},
@@ -112,8 +112,12 @@ class TestCmdReport(unittest.TestCase):
 
         mock_date_range.return_value = (MagicMock(), MagicMock())
         mock_settings.get_instance.return_value.load.return_value = AppConfig(
-            system=SystemConfig(start_of_day="00:00", day_start_source="manual"),
-            plugin_params=PluginParams(default_renderer="AI Context Renderer"),
+            system=SystemConfig(
+                start_of_day="00:00",
+                day_start_source="manual",
+                default_renderer="AI Context Renderer",
+            ),
+            plugins=PluginsConfig(),
         )
         mock_generator.return_value.run.return_value = (
             {},
@@ -139,7 +143,7 @@ class TestCmdReport(unittest.TestCase):
         mock_date_range.return_value = (MagicMock(), MagicMock())
         mock_settings.get_instance.return_value.load.return_value = AppConfig(
             system=SystemConfig(start_of_day="00:00", day_start_source="manual"),
-            plugin_params=PluginParams(),
+            plugins=PluginsConfig(),
         )
         mock_generator.return_value.run.return_value = (
             {},
@@ -163,7 +167,7 @@ class TestCmdReport(unittest.TestCase):
 
         mock_settings.get_instance.return_value.load.return_value = AppConfig(
             system=SystemConfig(start_of_day="00:00", day_start_source="manual"),
-            plugin_params=PluginParams(),
+            plugins=PluginsConfig(),
         )
         mock_date_range.side_effect = ValueError("Invalid date")
 
@@ -184,7 +188,7 @@ class TestCmdReport(unittest.TestCase):
         mock_date_range.return_value = (MagicMock(), MagicMock())
         mock_settings.get_instance.return_value.load.return_value = AppConfig(
             system=SystemConfig(start_of_day="00:00", day_start_source="aw"),
-            plugin_params=PluginParams(),
+            plugins=PluginsConfig(),
         )
         mock_client.return_value.get_setting.return_value = "04:00"
         mock_generator.return_value.run.return_value = ({}, [], [], {})
@@ -206,7 +210,7 @@ class TestCmdReport(unittest.TestCase):
         mock_date_range.return_value = (MagicMock(), MagicMock())
         mock_settings.get_instance.return_value.load.return_value = AppConfig(
             system=SystemConfig(start_of_day="06:00", day_start_source="aw"),
-            plugin_params=PluginParams(),
+            plugins=PluginsConfig(),
         )
         mock_client.return_value.get_setting.return_value = None  # AW returns None
         mock_generator.return_value.run.return_value = ({}, [], [], {})
@@ -230,7 +234,7 @@ class TestCmdReport(unittest.TestCase):
         mock_date_range.return_value = (MagicMock(), MagicMock())
         mock_settings.get_instance.return_value.load.return_value = AppConfig(
             system=SystemConfig(start_of_day="07:00", day_start_source="aw"),
-            plugin_params=PluginParams(),
+            plugins=PluginsConfig(),
         )
         mock_client.return_value.get_setting.side_effect = Exception("Connection failed")
         mock_generator.return_value.run.return_value = ({}, [], [], {})

--- a/tests/unit/test_plugins_renderer_ai.py
+++ b/tests/unit/test_plugins_renderer_ai.py
@@ -14,7 +14,7 @@ class TestAIRendererPlugin(unittest.TestCase):
 
     def setUp(self):
         self.renderer = AIRendererPlugin()
-        self.base_config = {"settings": {}}
+        self.base_config = {"plugins": {}}
         self.base_report_data = {
             "date": "2025-01-15",
             "work_stats": {"working_seconds": 3600},
@@ -36,17 +36,12 @@ class TestAIRendererPlugin(unittest.TestCase):
 
     def test_ai_prompt_included_when_configured(self):
         """ai_promptが設定されていれば出力に含まれる"""
-        config = {"settings": {"ai_prompt": "You are a helpful assistant."}}
+        plugin_id = self.renderer.plugin_id
+        config = {"plugins": {plugin_id: {"ai_prompt": "You are a helpful assistant."}}}
         result = self.renderer.render([], self.base_report_data, config)
         assert "You are a helpful assistant." in result
         assert "---" in result
         assert "Below is the activity log:" in result
-
-    def test_ai_prompt_fallback_from_root(self):
-        """settings.ai_promptがなくてもルートレベルのai_promptを使用"""
-        config = {"ai_prompt": "Root level prompt", "settings": {}}
-        result = self.renderer.render([], self.base_report_data, config)
-        assert "Root level prompt" in result
 
     def test_timeline_items_rendered(self):
         """タイムラインアイテムが正しく出力される"""

--- a/tests/unit/test_plugins_renderer_markdown.py
+++ b/tests/unit/test_plugins_renderer_markdown.py
@@ -20,7 +20,7 @@ class TestMarkdownRendererPlugin(unittest.TestCase):
             del os.environ["AW_SUPPRESS_TIMELINE"]
 
         self.renderer = MarkdownRendererPlugin()
-        self.base_config = {"settings": {"break_categories": []}}
+        self.base_config = {"system": {"break_categories": []}}
         self.base_report_data = {
             "date": "2025-01-15",
             "work_stats": {
@@ -81,7 +81,7 @@ class TestMarkdownRendererPlugin(unittest.TestCase):
 
     def test_break_categories_excluded(self):
         """break_categoriesに含まれるカテゴリは除外"""
-        config = {"settings": {"break_categories": ["Break", "Lunch"]}}
+        config = {"system": {"break_categories": ["Break", "Lunch"]}}
         report_data = {
             **self.base_report_data,
             "category_stats": {"Coding": 1800, "Lunch": 900},

--- a/tests/unit/test_plugins_required_settings.py
+++ b/tests/unit/test_plugins_required_settings.py
@@ -54,12 +54,12 @@ class TestProcessorPluginRequiredSettings(unittest.TestCase):
     """各プロセッサプラグインの required_settings テスト"""
 
     def test_afk_processor_requires_settings(self):
-        """AFKProcessor は settings キーを必要とする"""
+        """AFKProcessor は plugins キーを必要とする"""
         # Arrange
         plugin = AFKProcessor()
 
         # Act & Assert
-        assert plugin.required_settings == ["settings"]
+        assert plugin.required_settings == ["plugins"]
 
     def test_compression_processor_requires_apps(self):
         """CompressionProcessor は apps キーを必要とする"""
@@ -70,12 +70,12 @@ class TestProcessorPluginRequiredSettings(unittest.TestCase):
         assert plugin.required_settings == ["apps"]
 
     def test_project_extraction_processor_requires_settings(self):
-        """ProjectExtractionProcessor は settings キーを必要とする"""
+        """ProjectExtractionProcessor は plugins キーを必要とする"""
         # Arrange
         plugin = ProjectExtractionProcessor()
 
         # Act & Assert
-        assert plugin.required_settings == ["settings"]
+        assert plugin.required_settings == ["plugins"]
 
     def test_project_mapping_processor_requires_maps(self):
         """ProjectMappingProcessor は project_map, client_map, clients キーを必要とする"""
@@ -111,12 +111,12 @@ class TestRendererPluginRequiredSettings(unittest.TestCase):
     """レンダラプラグインの required_settings テスト"""
 
     def test_markdown_renderer_requires_settings(self):
-        """MarkdownRendererPlugin は settings キーを必要とする"""
+        """MarkdownRendererPlugin は system キーを必要とする"""
         # Arrange
         plugin = MarkdownRendererPlugin()
 
         # Act & Assert
-        assert plugin.required_settings == ["settings"]
+        assert plugin.required_settings == ["system"]
 
     def test_json_renderer_requires_nothing(self):
         """JSONRendererPlugin は設定を必要としない"""
@@ -127,12 +127,12 @@ class TestRendererPluginRequiredSettings(unittest.TestCase):
         assert plugin.required_settings == []
 
     def test_ai_renderer_requires_settings(self):
-        """AIRendererPlugin は settings キーを必要とする"""
+        """AIRendererPlugin は plugins キーを必要とする"""
         # Arrange
         plugin = AIRendererPlugin()
 
         # Act & Assert
-        assert plugin.required_settings == ["settings"]
+        assert plugin.required_settings == ["plugins"]
 
 
 class TestRequiredSettingsConsistency(unittest.TestCase):
@@ -141,7 +141,7 @@ class TestRequiredSettingsConsistency(unittest.TestCase):
     def test_all_required_settings_are_valid_config_keys(self):
         """すべてのプラグインの required_settings が有効な AppConfig キーである"""
         # Arrange
-        valid_keys = {"system", "settings", "rules", "project_map", "client_map", "apps", "clients"}
+        valid_keys = {"system", "plugins", "rules", "project_map", "client_map", "apps", "clients"}
         all_plugins = [
             AFKProcessor(),
             CompressionProcessor(),

--- a/tests/unit/test_timeline.py
+++ b/tests/unit/test_timeline.py
@@ -163,7 +163,7 @@ class TestTimelineGenerator(unittest.TestCase):
             self._create_item(0, 60),
             self._create_item(60, 30, category="Lunch"),
         ]
-        config = {"settings": {"break_categories": ["Lunch"]}}
+        config = {"system": {"break_categories": ["Lunch"]}}
 
         # Act
         stats = self.generator.analyze_working_hours(timeline, config)


### PR DESCRIPTION
Closes #48

## 概要

config.json のキー構造をプラグインIDベースに再設計し、設定の責任範囲を明確化します。

- `settings` キーを廃止し、プラグイン固有設定を `plugins.<plugin_id>` 配下に配置
- `default_renderer` などのコア設定を `system` に移動
- マイグレーション対応を実装

詳細は #48 を参照してください。

🤖 Generated with [Claude Code](https://claude.com/claude-code)